### PR TITLE
fixes ReversePolygon / ReversePolygons error

### DIFF
--- a/libs/clipper/src/cpp/clipper.cpp
+++ b/libs/clipper/src/cpp/clipper.cpp
@@ -2971,7 +2971,7 @@ void Clipper::JoinCommonEdges()
 }
 //------------------------------------------------------------------------------
 
-void ReversePolygons(Polygon& p)
+void ReversePolygon(Polygon& p)
 {
   std::reverse(p.begin(), p.end());
 }
@@ -2980,7 +2980,7 @@ void ReversePolygons(Polygon& p)
 void ReversePolygons(Polygons& p)
 {
   for (Polygons::size_type i = 0; i < p.size(); ++i)
-    ReversePolygons(p[i]);
+    ReversePolygon(p[i]);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This _actually_ fixes #6

I thought this was fixed in 4.10, but it looks like it wasn't.  It _has_ been fixed by 6.1.3a, although the functions are named differently now.
