### PR TITLE
Issue #10 Fix

### DIFF
--- a/src/ofxClipper.cpp
+++ b/src/ofxClipper.cpp
@@ -129,7 +129,7 @@ void ofxClipper::ofPath_to_Polygons(ofPath& path,ClipperLib::Paths& polygons) {
     return ofxPolylines_to_Polygons(path.getOutline(),polygons);
 }
 
-ClipperLib::Path ofxClipper::ofPolyline_to_Polygon(ofPolyline& polyline) {
+ClipperLib::Path ofxClipper::ofPolyline_to_Polygon(const ofPolyline& polyline) {
 	vector<ofPoint> verts = polyline.getVertices();
     vector<ofPoint>::iterator iter;
     ClipperLib::Path polygon;
@@ -142,8 +142,8 @@ ClipperLib::Path ofxClipper::ofPolyline_to_Polygon(ofPolyline& polyline) {
 }
 
 
-void ofxClipper::ofxPolylines_to_Polygons(ofxPolylines& polylines,ClipperLib::Paths& polygons) {
-    vector<ofPolyline>::iterator iter;
+void ofxClipper::ofxPolylines_to_Polygons(const ofxPolylines& polylines,ClipperLib::Paths& polygons) {
+    vector<ofPolyline>::const_iterator iter;
     for(iter = polylines.begin(); iter != polylines.end(); iter++) {
         polygons.push_back(ofPolyline_to_Polygon((*iter)));
     }
@@ -172,10 +172,37 @@ void ofxClipper::polygons_to_ofxPolylines(ClipperLib::Paths& polygons,ofxPolylin
 
 
 void ofxClipper::polygons_to_ofPath(ClipperLib::Paths& polygons,ofPath& path) {
+    
+    ofPath::Mode currentMode = path.getMode();
+    path.setMode(ofPath::POLYLINES);
+    
     vector<ClipperLib::Path>::iterator iter;
     for(iter = polygons.begin(); iter != polygons.end(); iter++) {
-        path.getOutline().push_back(polygon_to_ofPolyline((*iter)));
+        path.append(polygon_to_ofPath((*iter)));
     }
+    
+    path.setMode(currentMode);
+}
+
+ofPath ofxClipper::polygon_to_ofPath(ClipperLib::Path& polygon) {
+    vector<ClipperLib::IntPoint>::iterator iter;
+    ofPath path;
+    for(iter = polygon.begin(); iter != polygon.end(); iter++) {
+        
+        ofPoint pnt((*iter).X / double(clipperGlobalScale),  // bring back to our coords
+                    (*iter).Y / double(clipperGlobalScale)); // bring back to our coords
+        
+        if(iter == polygon.begin())
+        {
+            path.moveTo(pnt);
+        }
+        else
+        {
+            path.lineTo(pnt);
+        }
+    }
+    path.close(); // close it
+    return path;
 }
 
 

--- a/src/ofxClipper.h
+++ b/src/ofxClipper.h
@@ -118,13 +118,14 @@ public:
 //protected:
     // conversion functions
     static void ofPath_to_Polygons(ofPath& path, ClipperLib::Paths& polygons);
-    static ClipperLib::Path ofPolyline_to_Polygon(ofPolyline& polyline);
-    static void ofxPolylines_to_Polygons(ofxPolylines& polylines, ClipperLib::Paths& polygons);
+    static ClipperLib::Path ofPolyline_to_Polygon(const ofPolyline& polyline);
+    static void ofxPolylines_to_Polygons(const ofxPolylines& polylines, ClipperLib::Paths& polygons);
                 
                                       
     static ofPolyline polygon_to_ofPolyline(ClipperLib::Path& polygon);
     static void polygons_to_ofxPolylines(ClipperLib::Paths& polygons, ofxPolylines& polylines);
     static void polygons_to_ofPath(ClipperLib::Paths& polygons, ofPath& path);
+    static ofPath polygon_to_ofPath(ClipperLib::Path& polygon);
 
     static ClipperLib::PolyFillType convertWindingMode(ofPolyWindingMode windingMode);
 


### PR DESCRIPTION
Fixes Issue #10: https://github.com/bakercp/ofxClipper/issues/10

Changes in openframeworks ofPath class are the reason for this issue.  This code updates ofxClipper so it is compatible with the current state of ofPath.  Please be mindful that I am currently working off of a nightly build (of_v20160527_osx_release).
